### PR TITLE
Fix #401 More fix for truncating large file when uploading file

### DIFF
--- a/esp/eclwatch/ws_XSLT/dropzonefile.xslt
+++ b/esp/eclwatch/ws_XSLT/dropzonefile.xslt
@@ -145,6 +145,10 @@
               intervalId = setInterval("doBlink()",1000);
 
               document.forms['DropZoneForm'].action= url0;
+              if (!isFF)
+              {
+                document.forms['DropZoneForm'].submit();
+              }
               return true;
             }   
 


### PR DESCRIPTION
Previous fix disables the Submit button after a user clicks the
button and File Upload form will be submitted. For Firefox, the
upload form is submitted since onClick() return true. But, for
IE and Chrome, the upload form is not submitted even though the
onClick() return true. This fix detects the type of browser and,
if it is not Firefox, calls Submit function to submit the
upload form.

Signed-off-by: Kevin Wang kevin.wang@lexisnexis.com
